### PR TITLE
Currencies problems

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     implementation "co.aikar:acf-paper:0.5.1-SNAPSHOT"
     implementation "com.zaxxer:HikariCP:7.0.2"
 
-    compileOnly 'org.projectlombok:lombok:1.18.34'
-    annotationProcessor 'org.projectlombok:lombok:1.18.34'
+    compileOnly 'org.projectlombok:lombok:1.18.46'
+    annotationProcessor 'org.projectlombok:lombok:1.18.46'
 
     compileOnly("com.github.ben-manes.caffeine:caffeine:3.2.4")
 

--- a/plugin/src/main/java/it/alzy/simpleeconomy/plugin/commands/CurrenciesCommand.java
+++ b/plugin/src/main/java/it/alzy/simpleeconomy/plugin/commands/CurrenciesCommand.java
@@ -1,13 +1,9 @@
 package it.alzy.simpleeconomy.plugin.commands;
 
+import co.aikar.commands.annotation.*;
 import org.bukkit.entity.Player;
 
 import co.aikar.commands.BaseCommand;
-import co.aikar.commands.annotation.CommandAlias;
-import co.aikar.commands.annotation.CommandCompletion;
-import co.aikar.commands.annotation.CommandPermission;
-import co.aikar.commands.annotation.Optional;
-import co.aikar.commands.annotation.Subcommand;
 import it.alzy.simpleeconomy.plugin.SimpleEconomy;
 import it.alzy.simpleeconomy.plugin.i18n.enums.LanguageKeys;
 
@@ -20,6 +16,7 @@ public class CurrenciesCommand extends BaseCommand {
     private final SimpleEconomy plugin = SimpleEconomy.getInstance();
 
     @Subcommand("create|add")
+    @Syntax("<currencyName> <symbol>")
     public void createCurrency(Player player, String name, String symbol) {
         if (!player.hasPermission("simpleconomy.command.currencies.manage")) {
             plugin.getLanguageManager().send(player, LanguageKeys.NO_PERMISSION, "%prefix%", plugin.getLanguageManager().getMessage(LanguageKeys.PREFIX));
@@ -35,6 +32,7 @@ public class CurrenciesCommand extends BaseCommand {
 
     @Subcommand("delete|remove")
     @CommandCompletion("@currencies")
+    @Syntax("<currencyName>")
     public void deleteCurrency(Player player, String name) {
         if (!player.hasPermission("simpleconomy.command.currencies.manage")) {
             plugin.getLanguageManager().send(player, LanguageKeys.NO_PERMISSION, "%prefix%", plugin.getLanguageManager().getMessage(LanguageKeys.PREFIX));
@@ -49,8 +47,9 @@ public class CurrenciesCommand extends BaseCommand {
     }
 
     @Subcommand("symbol")
-    @CommandCompletion("@currencies")
-    public void changeSymbol(Player player, String name, @Optional String newSymbol) {
+    @CommandCompletion("@currencies @nothing")
+    @Syntax("<currencyName> <newSymbol>")
+    public void changeSymbol(Player player, String name, String newSymbol) {
         if (!player.hasPermission("simpleconomy.command.currencies.manage")) {
             plugin.getLanguageManager().send(player, LanguageKeys.NO_PERMISSION, "%prefix%", plugin.getLanguageManager().getMessage(LanguageKeys.PREFIX));
             return;
@@ -60,11 +59,12 @@ public class CurrenciesCommand extends BaseCommand {
             plugin.getLanguageManager().send(player, LanguageKeys.CURRENCY_NOT_FOUND, "%prefix%", plugin.getLanguageManager().getMessage(LanguageKeys.PREFIX), "%currency%", name);
             return;
         }
+        String oldSymbol = currency.getSymbol();
         if (newSymbol == null || newSymbol.isEmpty()) {
             newSymbol = "";
         }
         plugin.getCurrencyManager().changeSymbol(name, newSymbol);
-        plugin.getLanguageManager().send(player, LanguageKeys.CURRENCY_SYMBOL_CHANGED, "%prefix%", plugin.getLanguageManager().getMessage(LanguageKeys.PREFIX), "%currency%", name, "%symbol%", newSymbol);
+        plugin.getLanguageManager().send(player, LanguageKeys.CURRENCY_SYMBOL_CHANGED, "%prefix%", plugin.getLanguageManager().getMessage(LanguageKeys.PREFIX), "%currency%", name, "%symbol%", newSymbol, "%oldSymbol%", oldSymbol);
     }
 
     @Subcommand("list")

--- a/plugin/src/main/resources/languages/lang_en.yml
+++ b/plugin/src/main/resources/languages/lang_en.yml
@@ -56,6 +56,7 @@ messages:
     already-exists: "%prefix% &#F87171✘ &#EF4444The currency &#F9FAFB%currency% &#EF4444already exists!"
     not-found: "%prefix% &#F87171✘ &#EF4444The currency &#F9FAFB%currency% &#EF4444does not exist!"
     list-currency-empty: "%prefix% &#F87171✘ &#EF4444No available currencies!"
+    symbol-changed: "%prefix% &#86EFAC✔ &#6B7280Symbol changed for &#F9FAFB%currency% &#6B7280from &#F9FAFB%oldSymbol% &#6B7280to &#F9FAFB%symbol%"
   modules:
     list: "%prefix% &#6B7280Available modules: &#F9FAFB%modules%"
     no_modules: "%prefix% &#F87171✘ &#EF4444No modules available!"

--- a/plugin/src/main/resources/languages/lang_it.yml
+++ b/plugin/src/main/resources/languages/lang_it.yml
@@ -56,7 +56,7 @@ messages:
     already-exists: "%prefix% &#F87171✘ &#EF4444La valuta &#F9FAFB%currency% &#EF4444esiste già!"
     not-found: "%prefix% &#F87171✘ &#EF4444La valuta &#F9FAFB%currency% &#EF4444non esiste!"
     list-currency-empty: "%prefix% &#F87171✘ &#EF4444Nessuna valuta disponibile!"
-    symbol-changed: "%prefix% &#86EFAC✔ &#6B7280Simbolo di &#F9FAFB%currency% &#6B7280cambiato in &#F9FAFB%symbol%"
+    symbol-changed: "%prefix% &#86EFAC✔ &#6B7280Simbolo di &#F9FAFB%currency% &#6B7280cambiato da &#F9FAFB%oldSymbol% &#6B7280a &#F9FAFB%symbol%"
   modules:
     list: "%prefix% &#6B7280Moduli disponibili: &#F9FAFB%modules%"
     no_modules: "%prefix% &#F87171✘ &#EF4444Nessun modulo disponibile!"


### PR DESCRIPTION
chore(plugin:build.gradle): updated **lombok** to version `1.18.46`

fix+feat(CurrenciesCommand):
- removed completion duplication from `/currencies symbol`
- added syntax for subcommands who requires arguments
- added placeholder `%oldSymbol%` that matches the old symbol of the currency before any changes is applied

chore(lang_* files):
- fixed error "Key not found: messages.currencies.symbol-changed" in file `lang_en.yml`
- added examples for new placeholder %oldSymbol% in both `lang_en.yml` and `lang_it.yml`